### PR TITLE
Change the id test to a more strict equals assertion.

### DIFF
--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -651,7 +651,7 @@ describe('bedrock-account', () => {
           should.exist(e);
           e.name.should.contain('ValidationError');
           e.message.should.match(/patch\s+is\s+invalid/i);
-          e.details.errors.message.should.match(/can\s+not\s+change\s+id/i);
+          e.details.errors.message.should.equal('"id" cannot be changed');
         }
       });
 


### PR DESCRIPTION
adds a more strict equals assert for the errror thrown when you try to change an id.