### PR TITLE
Make account email indexes unique.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ bedrock.events.on('bedrock-mongodb.ready', async () => {
     fields: {'account.email': 1, 'meta.status': 1},
     options: {
       partialFilterExpression: {'account.email': {$exists: true}},
-      unique: false,
+      unique: true,
       background: false
     }
   }, {


### PR DESCRIPTION
Bug:

1. account1@example.com Registers.
2. account2@example.com Registers.
3. account2@example.com updates their email to be account1@example.com

Because the second `account.email` index is not unique you can change your email to another user's email.

Result:
The first account found by the email is the one logged in (should be the first user to register with that email address). This means account2@example.com essentially can not login by email (unless their password happens to be the same one as account1's password).